### PR TITLE
08 Tests

### DIFF
--- a/08-testing/01-application-tests/tasks/__tests__/tasks.e2e.test.ts
+++ b/08-testing/01-application-tests/tasks/__tests__/tasks.e2e.test.ts
@@ -2,43 +2,210 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import * as request from "supertest";
 import { AppModule } from "../../app.module";
-import { getRepositoryToken } from "@nestjs/typeorm";
+import { getRepositoryToken, TypeOrmModule } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Task } from "../entities/task.entity";
+import { CreateTaskDto } from "../dto/create-task.dto";
+import { UpdateTaskDto } from "../dto/update-task.dto";
 
 describe("TasksController (e2e)", () => {
   let app: INestApplication;
   let repository: Repository<Task>;
 
-  beforeAll(async () => {});
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        AppModule,
+        TypeOrmModule.forRoot({
+          type: "sqlite",
+          database: ":memory:",
+          entities: [Task],
+          synchronize: true,
+        }),
+      ],
+    }).compile();
 
-  afterAll(async () => {});
+    app = moduleFixture.createNestApplication();
+    await app.init();
 
-  beforeEach(async () => {});
+    repository = moduleFixture.get(getRepositoryToken(Task));
+  });
+
+  beforeEach(async () => {
+    await repository.clear();
+  });
+
+  afterEach(async () => {
+    await repository.clear();
+  })
+
+  afterAll(async () => {
+    await app.close();
+  });
 
   describe("GET /tasks", () => {
-    it("should return all tasks", async () => {});
+    it("should return all tasks", async () => {
+      const response1 = await request(app.getHttpServer()).get("/tasks/");
+      expect(response1.status).toBe(200);
+      expect(response1.body).toEqual([]);
+
+      const dto: CreateTaskDto = {
+        title: "First task",
+        description: "First task description",
+      };
+      const task = repository.create(dto);
+      await repository.save(task);
+
+      const response2 = await request(app.getHttpServer()).get("/tasks/");
+      expect(response2.status).toBe(200);
+      expect(response2.body).toEqual([
+        {
+          id: 1,
+          title: "First task",
+          description: "First task description",
+          isCompleted: false,
+        },
+      ]);
+    });
   });
 
   describe("GET /tasks/:id", () => {
-    it("should return task by id", async () => {});
+    it("should return task by id", async () => {
+      const existingId = 2;
 
-    it("should return 404 if task not found", async () => {});
+      const dto: CreateTaskDto = {
+        title: "First task",
+        description: "First task description",
+      };
+      const task = repository.create(dto);
+      await repository.save(task);
+
+      const response = await request(app.getHttpServer()).get(
+        `/tasks/${existingId}`,
+      );
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        id: 2,
+        title: "First task",
+        description: "First task description",
+        isCompleted: false,
+      });
+    });
+
+    it("should return 404 if task not found", async () => {
+      const nonExistingId = 100;
+
+      const response = await request(app.getHttpServer()).get(
+        `/tasks/${nonExistingId}`,
+      );
+      expect(response.status).toBe(404);
+      expect(response.body).toHaveProperty("error", "Not Found");
+    });
   });
 
   describe("POST /tasks", () => {
-    it("should create a new task", async () => {});
+    it("should create a new task", async () => {
+      const taskDto: CreateTaskDto = {
+        title: "New task",
+        description: "Super important task!",
+      };
+
+      //TODO beforeEach repository.clear() не работает? Почему-то учитываются индексы ранее сохранённых задач:
+      // при этом задачу с id == 1 не найти. Т.е. @PrimaryGeneratedColumn в БД не обнуляется после repository.clear?
+      // в документации к clear говорится следующее: Note: this method uses TRUNCATE and may not work as you expect in transactions on some platforms.
+      const task = await repository.findOne({ where: { id: 1 } });
+      console.log("==", task);
+      //TODO end
+
+      const response = await request(app.getHttpServer())
+        .post(`/tasks`)
+        .send(taskDto);
+      expect(response.status).toEqual(201);
+      expect(response.body).toEqual({
+        ...taskDto,
+        id: 1,
+        isComplete: false,
+      });
+    });
   });
 
   describe("PATCH /tasks/:id", () => {
-    it("should update an existing task", async () => {});
+    it("should update an existing task", async () => {
+      const dto: UpdateTaskDto = {
+        title: "Some task to update",
+        description: "Some task description",
+        isCompleted: true,
+      };
 
-    it("should return 404 when updating non-existent task", async () => {});
+      const task = repository.create(dto);
+      const savedTask = await repository.save(task);
+
+      const response = await request(app.getHttpServer())
+        .patch(`/tasks/${savedTask.id}`)
+        .send(dto);
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        ...dto,
+        id: savedTask.id,
+      });
+    });
+
+    it("should return 404 when updating non-existent task", async () => {
+      const nonExistingId = 100;
+
+      const dto: UpdateTaskDto = {
+        title: "Non existing task",
+        description: "Non existing task",
+        isCompleted: true,
+      };
+
+      const nonExistingTask = await repository.findOne({
+        where: { id: nonExistingId },
+      });
+      expect(nonExistingTask).toEqual(null);
+
+      const response = await request(app.getHttpServer())
+        .patch(`/tasks/${nonExistingId}`)
+        .send(dto);
+      expect(response.status).toBe(404);
+      expect(response.body).toHaveProperty("error", "Not Found");
+    });
   });
 
   describe("DELETE /tasks/:id", () => {
-    it("should delete an existing task", async () => {});
+    it("should delete an existing task", async () => {
+      const dto: CreateTaskDto = {
+        title: "Some task to delete",
+        description: "Some task description",
+      };
 
-    it("should return 404 when deleting non-existent task", async () => {});
+      const task = repository.create(dto);
+      const savedTask = await repository.save(task);
+      // repository.remove возвращает entity без id. описано в https://github.com/typeorm/typeorm/issues/7024#issuecomment-948519328
+      const { id, ...expectedRemovedTask } = savedTask;
+
+      const response = await request(app.getHttpServer()).delete(
+        `/tasks/${savedTask.id}`,
+      );
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        ...expectedRemovedTask,
+      });
+    });
+
+    it("should return 404 when deleting non-existent task", async () => {
+      const nonExistingId = 100;
+
+      const nonExistingTask = await repository.findOne({
+        where: { id: nonExistingId },
+      });
+      expect(nonExistingTask).toEqual(null);
+
+      const response = await request(app.getHttpServer()).delete(
+        `/tasks/${nonExistingId}`,
+      );
+      expect(response.status).toBe(404);
+      expect(response.body).toHaveProperty("error", "Not Found");
+    });
   });
 });

--- a/08-testing/01-application-tests/tasks/__tests__/tasks.unit.test.ts
+++ b/08-testing/01-application-tests/tasks/__tests__/tasks.unit.test.ts
@@ -6,15 +6,41 @@ import { CreateTaskDto } from "../dto/create-task.dto";
 import { UpdateTaskDto } from "../dto/update-task.dto";
 import { getRepositoryToken } from "@nestjs/typeorm";
 
+const DEFAULT_TASKS = [
+  {
+    title: "First task",
+    description: "First task description",
+  },
+  {
+    title: "Second task",
+    description: "Second task description",
+  },
+].map((dto, ind) => ({
+  ...dto,
+  id: ++ind,
+  isCompleted: false,
+}));
+
 describe("TasksService", () => {
   let service: TasksService;
 
-  let mockTasksRepository = {
-    create: jest.fn(),
-    save: jest.fn(),
-    find: jest.fn(),
-    findOneBy: jest.fn(),
-    remove: jest.fn(),
+  let mockedTasks = DEFAULT_TASKS.map((task) => ({ ...task }));
+
+  const mockTasksRepository = {
+    create: jest.fn((dto: CreateTaskDto) => {
+      let lastId = mockedTasks[mockedTasks.length - 1].id ?? 0;
+      return {
+        ...dto,
+        id: ++lastId,
+        isCompleted: false,
+      } as Task;
+    }),
+    save: jest.fn((task: Task) => task),
+    find: jest.fn(() => mockedTasks),
+    findOneBy: jest.fn(({ id: taskId }: { id: number }) =>
+      mockedTasks.find(({ id }) => id === taskId),
+    ),
+    remove: jest.fn((task: Task) => task),
   };
 
   beforeAll(async () => {
@@ -29,6 +55,7 @@ describe("TasksService", () => {
   });
 
   afterEach(() => {
+    mockedTasks = DEFAULT_TASKS.map((task) => ({ ...task }));
     jest.clearAllMocks();
   });
 
@@ -38,67 +65,25 @@ describe("TasksService", () => {
 
   describe("create", () => {
     it("should create a new task", async () => {
-      const mockedDto: CreateTaskDto = {
-        title: "First task",
-        description: "First task description",
+      const dto: CreateTaskDto = {
+        title: "Third task",
+        description: "Third task description",
       };
-      const mockedTask: Task = {
-        ...mockedDto,
-        id: 1,
+
+      let lastId = DEFAULT_TASKS[DEFAULT_TASKS.length - 1].id ?? 0;
+      const task: Task = {
+        ...dto,
+        id: ++lastId,
         isCompleted: false,
       };
-      mockTasksRepository.create.mockReturnValue(mockedTask);
-      mockTasksRepository.save.mockReturnValue(mockedTask);
 
-      const task = new Task();
-      Object.assign(task, mockedDto);
-
-      const savedTask = await service.create(task);
-      expect(savedTask).toEqual(mockedTask);
-
-      // const taskInDb = await repository.findOneBy({ id: 1 });
-      // expect(savedTask).toEqual(taskInDb);
+      const savedTask = await service.create(dto);
+      expect(savedTask).toEqual(task);
     });
   });
 
   describe("findAll", () => {
     it("should return an array of tasks", async () => {
-      const mockedDtos: CreateTaskDto[] = [
-        {
-          title: "First task",
-          description: "First task description",
-        },
-        {
-          title: "Second task",
-          description: "Second task description",
-        },
-      ];
-      const mockedTasks = mockedDtos.map((dto, ind) => ({
-        ...dto,
-        id: ind,
-        isCompleted: false,
-      }));
-
-      mockTasksRepository.create.mockImplementation((dto: CreateTaskDto) => {
-        return mockedTasks.find(
-          ({ title, description }) =>
-            title === dto.title && description === dto.description,
-        );
-      });
-      mockTasksRepository.save.mockImplementation((dto: CreateTaskDto) => {
-        return mockedTasks.find(
-          ({ title, description }) =>
-            title === dto.title && description === dto.description,
-        );
-      });
-      mockTasksRepository.find.mockReturnValue(mockedTasks);
-
-      for (const dto of mockedDtos) {
-        const _task = new Task();
-        Object.assign(_task, dto);
-        await service.create(_task);
-      }
-
       const tasks = await service.findAll();
 
       expect(Array.isArray(tasks)).toEqual(true);
@@ -107,54 +92,16 @@ describe("TasksService", () => {
   });
 
   describe("findOne", () => {
-    let mockedDtos: CreateTaskDto[] = [];
-    let mockedTasks: Task[] = [];
-
-    beforeEach(async () => {
-      mockedDtos = [
-        {
-          title: "First task",
-          description: "First task description",
-        },
-        {
-          title: "Second task",
-          description: "Second task description",
-        },
-      ];
-
-      for (const dto of mockedDtos) {
-        const _task = new Task();
-        Object.assign(_task, dto);
-        await service.create(_task);
-      }
-
-      mockedTasks = mockedDtos.map((dto, ind) => ({
-        ...dto,
-        id: ++ind,
-        isCompleted: false,
-      }));
-    });
-
     it("should return a task when it exists", async () => {
-      mockTasksRepository.findOneBy.mockImplementation(
-        ({ id: taskId }: { id: number }) =>
-          mockedTasks.find(({ id }) => id === taskId),
-      );
-
       const firstTask = await service.findOne(1);
-      expect(firstTask).toEqual(mockedTasks[0]);
+      expect(firstTask).toEqual(DEFAULT_TASKS[0]);
 
       const secondTask = await service.findOne(2);
-      expect(secondTask).toEqual(mockedTasks[1]);
-      expect(firstTask).not.toEqual(mockedTasks[1]);
+      expect(secondTask).toEqual(DEFAULT_TASKS[1]);
+      expect(firstTask).not.toEqual(DEFAULT_TASKS[1]);
     });
 
     it("should throw NotFoundException when task does not exist", async () => {
-      const spy = jest.spyOn(mockTasksRepository, "findOneBy");
-      spy.mockImplementation(
-        (taskId: number) => mockedTasks.find(({ id }) => id === taskId) ?? null,
-      );
-
       try {
         await service.findOne(3);
       } catch (error) {
@@ -164,39 +111,6 @@ describe("TasksService", () => {
   });
 
   describe("update", () => {
-    let mockedDtos: CreateTaskDto[] = [];
-    let mockedTasks: Task[] = [];
-
-    beforeEach(async () => {
-      mockedDtos = [
-        {
-          title: "First task",
-          description: "First task description",
-        },
-      ];
-
-      for (const dto of mockedDtos) {
-        const _task = new Task();
-        Object.assign(_task, dto);
-        await service.create(_task);
-      }
-
-      mockedTasks = mockedDtos.map((dto, ind) => ({
-        ...dto,
-        id: ++ind,
-        isCompleted: false,
-      }));
-
-      mockTasksRepository.findOneBy.mockImplementation(
-        ({ id: taskId }: { id: number }) =>
-          mockedTasks.find(({ id }) => id === taskId) ?? null,
-      );
-      mockTasksRepository.save.mockImplementation(
-        ({ id: taskId }: { id: number }) =>
-          mockedTasks.find(({ id }) => id === taskId) ?? null,
-      );
-    });
-
     it("should update a task when it exists", async () => {
       const firstTask = await service.findOne(1);
       const updatedTask: Task = {
@@ -225,41 +139,11 @@ describe("TasksService", () => {
   });
 
   describe("remove", () => {
-    let mockedDtos: CreateTaskDto[] = [];
-    let mockedTasks: Task[] = [];
-
-    beforeEach(async () => {
-      mockedDtos = [
-        {
-          title: "First task",
-          description: "First task description",
-        },
-      ];
-
-      for (const dto of mockedDtos) {
-        const _task = new Task();
-        Object.assign(_task, dto);
-        await service.create(_task);
-      }
-
-      mockedTasks = mockedDtos.map((dto, ind) => ({
-        ...dto,
-        id: ++ind,
-        isCompleted: false,
-      }));
-
-      mockTasksRepository.findOneBy.mockImplementation(
-        ({ id: taskId }: { id: number }) =>
-          mockedTasks.find(({ id }) => id === taskId) ?? null,
-      );
-      mockTasksRepository.remove.mockImplementation((task: Task) => task);
-    });
-
     it("should remove a task when it exists", async () => {
       const taskId = 1;
       const task = await service.remove(taskId);
 
-      expect(task).toEqual(mockedTasks.find(({ id }) => id === taskId));
+      expect(task).toEqual(DEFAULT_TASKS.find(({ id }) => id === taskId));
     });
 
     it("should throw NotFoundException when task to remove does not exist", async () => {

--- a/08-testing/01-application-tests/tasks/__tests__/tasks.unit.test.ts
+++ b/08-testing/01-application-tests/tasks/__tests__/tasks.unit.test.ts
@@ -1,17 +1,15 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { TasksService } from "../tasks.service";
-import { getRepositoryToken } from "@nestjs/typeorm";
 import { Task } from "../entities/task.entity";
-import { Repository } from "typeorm";
 import { NotFoundException } from "@nestjs/common";
 import { CreateTaskDto } from "../dto/create-task.dto";
 import { UpdateTaskDto } from "../dto/update-task.dto";
+import { getRepositoryToken } from "@nestjs/typeorm";
 
 describe("TasksService", () => {
   let service: TasksService;
-  let repository: Repository<Task>;
 
-  const mockTasksRepository = {
+  let mockTasksRepository = {
     create: jest.fn(),
     save: jest.fn(),
     find: jest.fn(),
@@ -19,31 +17,259 @@ describe("TasksService", () => {
     remove: jest.fn(),
   };
 
-  beforeEach(async () => {});
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TasksService,
+        { provide: getRepositoryToken(Task), useValue: mockTasksRepository },
+      ],
+    }).compile();
+
+    service = module.get(TasksService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("Должен быть определён", () => {
+    expect(service).toBeDefined();
+  });
 
   describe("create", () => {
-    it("should create a new task", async () => {});
+    it("should create a new task", async () => {
+      const mockedDto: CreateTaskDto = {
+        title: "First task",
+        description: "First task description",
+      };
+      const mockedTask: Task = {
+        ...mockedDto,
+        id: 1,
+        isCompleted: false,
+      };
+      mockTasksRepository.create.mockReturnValue(mockedTask);
+      mockTasksRepository.save.mockReturnValue(mockedTask);
+
+      const task = new Task();
+      Object.assign(task, mockedDto);
+
+      const savedTask = await service.create(task);
+      expect(savedTask).toEqual(mockedTask);
+
+      // const taskInDb = await repository.findOneBy({ id: 1 });
+      // expect(savedTask).toEqual(taskInDb);
+    });
   });
 
   describe("findAll", () => {
-    it("should return an array of tasks", async () => {});
+    it("should return an array of tasks", async () => {
+      const mockedDtos: CreateTaskDto[] = [
+        {
+          title: "First task",
+          description: "First task description",
+        },
+        {
+          title: "Second task",
+          description: "Second task description",
+        },
+      ];
+      const mockedTasks = mockedDtos.map((dto, ind) => ({
+        ...dto,
+        id: ind,
+        isCompleted: false,
+      }));
+
+      mockTasksRepository.create.mockImplementation((dto: CreateTaskDto) => {
+        return mockedTasks.find(
+          ({ title, description }) =>
+            title === dto.title && description === dto.description,
+        );
+      });
+      mockTasksRepository.save.mockImplementation((dto: CreateTaskDto) => {
+        return mockedTasks.find(
+          ({ title, description }) =>
+            title === dto.title && description === dto.description,
+        );
+      });
+      mockTasksRepository.find.mockReturnValue(mockedTasks);
+
+      for (const dto of mockedDtos) {
+        const _task = new Task();
+        Object.assign(_task, dto);
+        await service.create(_task);
+      }
+
+      const tasks = await service.findAll();
+
+      expect(Array.isArray(tasks)).toEqual(true);
+      expect(tasks.length).toEqual(2);
+    });
   });
 
   describe("findOne", () => {
-    it("should return a task when it exists", async () => {});
+    let mockedDtos: CreateTaskDto[] = [];
+    let mockedTasks: Task[] = [];
 
-    it("should throw NotFoundException when task does not exist", async () => {});
+    beforeEach(async () => {
+      mockedDtos = [
+        {
+          title: "First task",
+          description: "First task description",
+        },
+        {
+          title: "Second task",
+          description: "Second task description",
+        },
+      ];
+
+      for (const dto of mockedDtos) {
+        const _task = new Task();
+        Object.assign(_task, dto);
+        await service.create(_task);
+      }
+
+      mockedTasks = mockedDtos.map((dto, ind) => ({
+        ...dto,
+        id: ++ind,
+        isCompleted: false,
+      }));
+    });
+
+    it("should return a task when it exists", async () => {
+      mockTasksRepository.findOneBy.mockImplementation(
+        ({ id: taskId }: { id: number }) =>
+          mockedTasks.find(({ id }) => id === taskId),
+      );
+
+      const firstTask = await service.findOne(1);
+      expect(firstTask).toEqual(mockedTasks[0]);
+
+      const secondTask = await service.findOne(2);
+      expect(secondTask).toEqual(mockedTasks[1]);
+      expect(firstTask).not.toEqual(mockedTasks[1]);
+    });
+
+    it("should throw NotFoundException when task does not exist", async () => {
+      const spy = jest.spyOn(mockTasksRepository, "findOneBy");
+      spy.mockImplementation(
+        (taskId: number) => mockedTasks.find(({ id }) => id === taskId) ?? null,
+      );
+
+      try {
+        await service.findOne(3);
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException);
+      }
+    });
   });
 
   describe("update", () => {
-    it("should update a task when it exists", async () => {});
+    let mockedDtos: CreateTaskDto[] = [];
+    let mockedTasks: Task[] = [];
 
-    it("should throw NotFoundException when task to update does not exist", async () => {});
+    beforeEach(async () => {
+      mockedDtos = [
+        {
+          title: "First task",
+          description: "First task description",
+        },
+      ];
+
+      for (const dto of mockedDtos) {
+        const _task = new Task();
+        Object.assign(_task, dto);
+        await service.create(_task);
+      }
+
+      mockedTasks = mockedDtos.map((dto, ind) => ({
+        ...dto,
+        id: ++ind,
+        isCompleted: false,
+      }));
+
+      mockTasksRepository.findOneBy.mockImplementation(
+        ({ id: taskId }: { id: number }) =>
+          mockedTasks.find(({ id }) => id === taskId) ?? null,
+      );
+      mockTasksRepository.save.mockImplementation(
+        ({ id: taskId }: { id: number }) =>
+          mockedTasks.find(({ id }) => id === taskId) ?? null,
+      );
+    });
+
+    it("should update a task when it exists", async () => {
+      const firstTask = await service.findOne(1);
+      const updatedTask: Task = {
+        ...firstTask,
+        title: "Updated first task",
+        isCompleted: true,
+      };
+
+      const result = await service.update(1, updatedTask);
+      expect(result).toEqual(updatedTask);
+    });
+
+    it("should throw NotFoundException when task to update does not exist", async () => {
+      try {
+        const updatedTask: UpdateTaskDto = {
+          title: "Updated task",
+          description: "Updated task description",
+          isCompleted: true,
+        };
+
+        await service.update(100, updatedTask);
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException);
+      }
+    });
   });
 
   describe("remove", () => {
-    it("should remove a task when it exists", async () => {});
+    let mockedDtos: CreateTaskDto[] = [];
+    let mockedTasks: Task[] = [];
 
-    it("should throw NotFoundException when task to remove does not exist", async () => {});
+    beforeEach(async () => {
+      mockedDtos = [
+        {
+          title: "First task",
+          description: "First task description",
+        },
+      ];
+
+      for (const dto of mockedDtos) {
+        const _task = new Task();
+        Object.assign(_task, dto);
+        await service.create(_task);
+      }
+
+      mockedTasks = mockedDtos.map((dto, ind) => ({
+        ...dto,
+        id: ++ind,
+        isCompleted: false,
+      }));
+
+      mockTasksRepository.findOneBy.mockImplementation(
+        ({ id: taskId }: { id: number }) =>
+          mockedTasks.find(({ id }) => id === taskId) ?? null,
+      );
+      mockTasksRepository.remove.mockImplementation((task: Task) => task);
+    });
+
+    it("should remove a task when it exists", async () => {
+      const taskId = 1;
+      const task = await service.remove(taskId);
+
+      expect(task).toEqual(mockedTasks.find(({ id }) => id === taskId));
+    });
+
+    it("should throw NotFoundException when task to remove does not exist", async () => {
+      const taskId = 100;
+
+      try {
+        await service.remove(taskId);
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotFoundException);
+      }
+    });
   });
 });

--- a/08-testing/01-application-tests/tasks/tasks.controller.ts
+++ b/08-testing/01-application-tests/tasks/tasks.controller.ts
@@ -16,27 +16,27 @@ export class TasksController {
   constructor(private readonly tasksService: TasksService) {}
 
   @Post()
-  create(@Body() createTaskDto: CreateTaskDto) {
-    return this.tasksService.create(createTaskDto);
+  async create(@Body() createTaskDto: CreateTaskDto) {
+    return await this.tasksService.create(createTaskDto);
   }
 
   @Get()
-  findAll() {
+  async findAll() {
     return this.tasksService.findAll();
   }
 
   @Get(":id")
-  findOne(@Param("id") id: number) {
-    return this.tasksService.findOne(id);
+  async findOne(@Param("id") id: number) {
+    return await this.tasksService.findOne(id);
   }
 
   @Patch(":id")
-  update(@Param("id") id: number, @Body() updateTaskDto: UpdateTaskDto) {
-    return this.tasksService.update(id, updateTaskDto);
+  async update(@Param("id") id: number, @Body() updateTaskDto: UpdateTaskDto) {
+    return await this.tasksService.update(id, updateTaskDto);
   }
 
   @Delete(":id")
-  remove(@Param("id") id: number) {
-    return this.tasksService.remove(id);
+  async remove(@Param("id") id: number) {
+    return await this.tasksService.remove(id);
   }
 }

--- a/08-testing/01-application-tests/tasks/tasks.service.ts
+++ b/08-testing/01-application-tests/tasks/tasks.service.ts
@@ -11,9 +11,9 @@ export class TasksService {
     @InjectRepository(Task) private readonly tasksRepository: Repository<Task>,
   ) {}
 
-  create(createTaskDto: CreateTaskDto) {
+  async create(createTaskDto: CreateTaskDto) {
     const task = this.tasksRepository.create(createTaskDto);
-    return this.tasksRepository.save(task);
+    return await this.tasksRepository.save(task);
   }
 
   async findAll() {
@@ -34,8 +34,8 @@ export class TasksService {
     return await this.tasksRepository.save(task);
   }
 
-  async remove(id: number): Promise<void> {
+  async remove(id: number): Promise<Task> {
     const task = await this.findOne(id);
-    await this.tasksRepository.remove(task);
+    return await this.tasksRepository.remove(task);
   }
 }


### PR DESCRIPTION
Несмотря на то, что чищу БД до/после каждого теста, тест e2e тест "should create a new task" падает. Перед созданием задачи проверяю, есть ли задача с id == 1 (руками проверял, есть ли с id 2 и 3). Её нет. Сохраняю и ожидаю, что сохранится задача с id == 1, но возвращается с id == 3 (или 4). Как будто учитываются все задачи из предыдущих тестов.
В документации к clear говорится следующее: Note: this method uses TRUNCATE and may not work as you expect in transactions on some platforms.
Уж не знаю, это у меня так локально работает или всё же ошибаюсь сам.
@tadjik1 , подскажи, пожалуйста, в чем может быть дело?